### PR TITLE
Expanded InsertCodeToFile options

### DIFF
--- a/src/functions/createMAsubsystem.ts
+++ b/src/functions/createMAsubsystem.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { InsertLocation, insertCodeIntoFile, insertCodeIntoFileFromExampleRegex } from './insertCodeIntoFile';
 
 
 
@@ -66,17 +67,7 @@ export function createMAsubsytem(uri: vscode.Uri) {
                         const portmapExampleFilePath = path.join(baseDir, "src", "main", "java", "com", "ma5951", "MAutils", "MA-extention-files", "example", "SubsystemsType" ,'PortMapExample.java');
 
                         if (fs.existsSync(portmapFilePath)) {
-                            let portmapcontent = fs.readFileSync(portmapFilePath).toString().split('\n');
-                            portmapcontent.pop();
-                            let result = portmapcontent.join('\n');
-                            fs.writeFileSync(portmapFilePath, result); 
-                            const portmapexamplefileContent =  fs.readFileSync(portmapExampleFilePath, 'utf8');
-                            const portmapsubsystemfileContent = portmapexamplefileContent.replace(/{{fileName}}/g, fileName);
-                            fs.writeFile(portmapFilePath, portmapsubsystemfileContent , {flag: 'a'}, err => { 
-                                if(err) { 
-                                throw err; 
-                                console.log("The subsystem has benn writtern to the PortMap successfully."); 
-                                }}); 
+                            insertCodeIntoFileFromExampleRegex(portmapFilePath, "PortMap", portmapExampleFilePath,"{{fileName}}", fileName ,InsertLocation.EndOfClass);
 
                         } else {
                             vscode.window.showErrorMessage(`Directory '${portmapFilePath}' not found. Make sure the PortMap file is created and in the right directory.`);

--- a/src/functions/insertCodeIntoFile.ts
+++ b/src/functions/insertCodeIntoFile.ts
@@ -33,7 +33,7 @@ function findClosingBraceIndex(content: string, startIndex: number): number {
     return -1;
 }
 
-export function insertCodeIntoFile(filePath: string, targetName: string, codeLines: string[], insertLocation: InsertLocation, afterLocation?: string): void {
+export function insertCodeIntoFile(filePath: string, targetName: string, codeLines: string, insertLocation: InsertLocation, afterLocation?: string): void {
     let insertionPoint: number | undefined;
     if (fs.existsSync(filePath)) {
         const fileContent = fs.readFileSync(filePath, 'utf8');
@@ -79,7 +79,7 @@ export function insertCodeIntoFile(filePath: string, targetName: string, codeLin
             }
 
             const updatedContent =
-                fileContent.slice(0, insertionPoint) + codeLines.join('\n') + '\n' + '\n' +
+                fileContent.slice(0, insertionPoint) + codeLines + '\n' +
                 fileContent.slice(insertionPoint) ;
 
             console.log(updatedContent);
@@ -94,11 +94,10 @@ export function insertCodeIntoFile(filePath: string, targetName: string, codeLin
         if ( insertionPoint === undefined || insertionPoint < 0 || insertionPoint > fileContent.length) {
             throw new Error('Invalid insertion point calculation.');
         }
-    try {
+        try {
         const updatedContent =
-            fileContent.slice(0, insertionPoint) +
-            '\n' + codeLines.join('\n') +
-            fileContent.slice(insertionPoint);
+        fileContent.slice(0, insertionPoint) + codeLines + '\n' +
+        fileContent.slice(insertionPoint) ;
 
         fs.writeFileSync(filePath, updatedContent);
         vscode.window.showInformationMessage(`Code inserted into ${targetName} successfully.`);
@@ -107,6 +106,18 @@ export function insertCodeIntoFile(filePath: string, targetName: string, codeLin
         vscode.window.showErrorMessage("Error inserting code into file");
     }
 }
+}
+
+export function insertCodeIntoFileFromExample(filePath: string, targetName: string, path: string, insertLocation: InsertLocation, afterLocation?: string): void {
+    let codelines = fs.readFileSync(path, 'utf8');
+    insertCodeIntoFile(filePath, targetName, codelines, insertLocation, afterLocation);
+}
+
+export function insertCodeIntoFileFromExampleRegex(filePath: string, targetName: string, path: string, regexExpresion: string, regexValue: string,insertLocation: InsertLocation, afterLocation?: string): void {
+    let codelines = fs.readFileSync(path, 'utf8');
+    const regex = new RegExp(regexExpresion, "g");
+    codelines = codelines.replace(regex, regexValue)
+    insertCodeIntoFile(filePath, targetName, codelines, insertLocation, afterLocation);
 }
 // // Example usage:
 // const filePath = '/path/to/your/example.java';


### PR DESCRIPTION
changed InsaertCodeToFile to get string as code to insert instead of arry (easier to manipulate).

Added InsertCodeToFileFromExample, just pass file path instead of code to insert and the function will read the file content and use it as code to insert

Added InsertCodeToFileFromExampleRegex, same as InsertCodeToFileFromExample but with the option to use regex in the example file. pass the regex expression used in the example file and the value to replace the regex with.